### PR TITLE
updates for Example CI

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ''
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: '1' # 1.6
           arch: x64

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         with:
           ref: ''
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: '1' # 1.6
           arch: x64

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         with:
           ref: ''
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: '1' # 1.6
           arch: x64

--- a/.github/workflows/Eval.yml
+++ b/.github/workflows/Eval.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -32,7 +32,7 @@ jobs:
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/Eval.yml
+++ b/.github/workflows/Eval.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@latest
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -32,7 +32,7 @@ jobs:
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v2
+        uses: actions/cache@latest
         env:
           cache-name: cache-artifacts
         with:
@@ -45,7 +45,7 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
 
       # Run PkgEval
       - name: "Run PkgEval"

--- a/.github/workflows/Eval.yml
+++ b/.github/workflows/Eval.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repository
-        uses: actions/checkout@latest
+        uses: actions/checkout@v2
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -32,7 +32,7 @@ jobs:
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@latest
+        uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
@@ -45,7 +45,7 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
 
       # Run PkgEval
       - name: "Run PkgEval"

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -27,10 +27,10 @@ jobs:
         
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
@@ -60,7 +60,7 @@ jobs:
           
       - name: Archive examples artifacts (success)
         if: success() && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@latest
         with:
           name: jupyter-examples
           path: examples/jupyter-src/${{ matrix.file-name }}*
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
             version: '1.10'
             
@@ -81,7 +81,7 @@ jobs:
       
       - name: Archive examples artifacts (success)
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@latest
         with:
           name: pluto-examples
           path: examples/pluto-src/*
@@ -91,19 +91,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download jupyter examples
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@latest
         with:
           name: jupyter-examples
           path: examples/jupyter-src/
           
       - name: Download pluto examples
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@latest
         with:
           name: pluto-examples
           path: examples/pluto-src/
           
       - name: Check if the example files generated are valid (if jupyter-examples failed, svgs are missing; jupyter command does not fail even if examples fail)
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@latest
         with: 
           files: "examples/jupyter-src/*/*.svg"
           fail: true
@@ -114,16 +114,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         
       - name: Download jupyter examples
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@latest
         with:
           name: jupyter-examples
           path: examples/jupyter-src/
       
       - name: Download pluto examples
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@latest
         with:
           name: pluto-examples
           path: examples/pluto-src/
@@ -160,6 +160,6 @@ jobs:
     steps:
       # Trigger an repoisitory dispath event
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@latest
         with:
           event-type: trigger-docu

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -12,15 +12,47 @@ on:
       - 'examples/pluto-src/**'
       - '.github/workflows/Example.yml'
       - 'Project.toml'
+
+concurrency: # allow only one parallel job as conflicts can emerge from example-gathering branch
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
   
 jobs:
-  jupyter-compute:
+  clean-ci-example-gathering-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+        
+      - name: "clean branch"
+        env: 
+          CI_COMMIT_MESSAGE: cleaned
+          CI_COMMIT_AUTHOR: github-actions[bot]
+          EXAMPLES_PATH: examples
+        # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
+        # Reset the branch and remove all current files in the examples folder. 
+        # Checkout the last stash to restore the new notebooks and apply the stash index to restore all other new files in the folder.
+        run: |
+          git fetch --all
+          git stash clear
+          git switch ci-example-gathering
+          git reset --hard origin/ci-example-gathering
+          rm -rf ${{ env.EXAMPLES_PATH }}
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
+          git config --global core.autocrlf false
+          git add ${{ env.EXAMPLES_PATH }}
+          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push origin ci-example-gathering 
+
+  jupyter:
+    needs: [clean-ci-example-gathering-branch]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest] # , ubuntu-latest]
-        file-name: [growing_horizon_ME, modelica_conference_2021, simple_hybrid_CS, simple_hybrid_ME, mdpi_2022, juliacon_2023] # Caution: if altered, alter jupyter-gather-job matrix too !!!
+        file-name: [growing_horizon_ME, modelica_conference_2021, simple_hybrid_CS, simple_hybrid_ME, mdpi_2022, juliacon_2023]
         julia-version: ['1.10'] 
         julia-arch: [x64]
         experimental: [false]
@@ -58,32 +90,33 @@ jobs:
           mv -Force examples/jupyter-src/tmp_${{ matrix.file-name }}.md examples/jupyter-src/${{ matrix.file-name }}.md
           echo "gifs should be fixed"
           
-      - name: Archive examples artifacts (success)
-        if: success() && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
-          path: examples/jupyter-src/${{ matrix.file-name }}*
-
-  jupyter-gather:
-    needs: jupyter-compute
-    runs-on: ubuntu-latest
-    env: 
-      JUPYTER_EXAMPLES: [windows-latest-growing_horizon_ME-1.10-x64-false, windows-latest-modelica_conference_2021-1.10-x64-false, windows-latest-simple_hybrid_CS-1.10-x64-false, windows-latest-simple_hybrid_ME-1.10-x64-false, windows-latest-mdpi_2022-1.10-x64-false, windows-latest-juliacon_2023-1.10-x64-false] # Caution: if altered, alter jupyter-compute-job matrix too !!!
-    steps:
-      - name: "gather jupyter artifacts"
-        uses: actions/download-artifact@v3
-        with:
-          name: jupyter-example-jupyter-example-$JUPYTER_EXAMPLES
-          path: examples/jupyter-src/
-      
-      - name: "upload combined jupyter artifact"
-        uses: actions/upload-artifact@v4
-        with:
-          name: jupyter-examples
-          path: examples/jupyter-src/*
+      - name: "auto-commit for gathering"
+        if: success()
+        env: 
+          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
+          CI_COMMIT_AUTHOR: github-actions[bot]
+          EXAMPLES_PATH: examples
+        # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
+        # Reset the branch and remove all current files in the examples folder. 
+        # Checkout the last stash to restore the new notebooks and apply the stash index to restore all other new files in the folder.
+        run: |
+          git fetch --all
+          git stash clear
+          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+          git switch ci-example-gathering
+          git reset --hard origin/ci-example-gathering
+          git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
+          git stash apply --index
+          git stash drop
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
+          git config --global core.autocrlf false
+          git add ${{ env.EXAMPLES_PATH }}
+          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push origin ci-example-gathering 
 
   pluto:
+    needs: [clean-ci-example-gathering-branch]
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
@@ -97,29 +130,43 @@ jobs:
       - run: julia -e 'using Pkg; Pkg.add("PlutoSliderServer"); Pkg.add("FMIFlux")'
       - run: julia -e 'using PlutoSliderServer; PlutoSliderServer.export_directory("examples/pluto-src")'
       
-      - name: Archive examples artifacts (success)
+      - name: "auto-commit for gathering"
         if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pluto-examples
-          path: examples/pluto-src/*
+        env: 
+          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
+          CI_COMMIT_AUTHOR: github-actions[bot]
+          EXAMPLES_PATH: examples
+        # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
+        # Reset the branch and remove all current files in the examples folder. 
+        # Checkout the last stash to restore the new notebooks and apply the stash index to restore all other new files in the folder.
+        run: |
+          git fetch --all
+          git stash clear
+          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+          git switch ci-example-gathering
+          git reset --hard origin/ci-example-gathering
+          git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
+          git stash apply --index
+          git stash drop
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
+          git config --global core.autocrlf false
+          git add ${{ env.EXAMPLES_PATH }}
+          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push origin ci-example-gathering 
           
   filecheck: 
-    needs: [jupyter-gather, pluto]
+    needs: [jupyter, pluto]
     runs-on: ubuntu-latest
     steps:
-      - name: Download jupyter examples
-        uses: actions/download-artifact@v3
-        with:
-          name: jupyter-examples
-          path: examples/jupyter-src/
-          
-      - name: Download pluto examples
-        uses: actions/download-artifact@v3
-        with:
-          name: pluto-examples
-          path: examples/pluto-src/
-          
+      - name: Download examples
+        run: |
+          git fetch --all
+          git stash clear
+          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+          git switch ci-example-gathering
+          git reset --hard origin/ci-example-gathering
+
       - name: Check if the example files generated are valid (if jupyter-examples failed, svgs are missing; jupyter command does not fail even if examples fail)
         uses: andstor/file-existence-action@v3
         with: 
@@ -127,24 +174,20 @@ jobs:
           fail: true
           
   auto-commit:
-    needs: [jupyter-gather, pluto, filecheck]
+    needs: [jupyter, pluto, filecheck]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         
-      - name: Download jupyter examples
-        uses: actions/download-artifact@v3
-        with:
-          name: jupyter-examples
-          path: examples/jupyter-src/
-      
-      - name: Download pluto examples
-        uses: actions/download-artifact@v3
-        with:
-          name: pluto-examples
-          path: examples/pluto-src/
+      - name: Download examples
+        run: |
+          git fetch --all
+          git stash clear
+          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+          git switch ci-example-gathering
+          git reset --hard origin/ci-example-gathering
           
       - name: auto-commit
         env: 

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -16,7 +16,7 @@ on:
 concurrency: # allow only one parallel job as conflicts can emerge from example-gathering branch
   group: ${{ github.workflow }}
   cancel-in-progress: true
-  
+
 jobs:
   clean-ci-example-gathering-branch:
     runs-on: ubuntu-latest
@@ -56,23 +56,23 @@ jobs:
         julia-version: ['1.10'] 
         julia-arch: [x64]
         experimental: [false]
-        
+
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-        
+
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@latest
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
-            
+
       - name: "Install dependencies"
         run: julia --project=examples/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-        
+
       - name: "Install packages"
         run: pip install jupyter nbconvert
-                        
+
       - name: "Execute and synchronize all files"
         env:
           FILE: examples/jupyter-src/${{ matrix.file-name }}.ipynb
@@ -80,7 +80,7 @@ jobs:
           jupyter nbconvert --ExecutePreprocessor.kernel_name="julia-1.10" --to notebook --inplace --execute ${{ env.FILE }}
           jupyter nbconvert --to script ${{ env.FILE }}
           jupyter nbconvert --to markdown ${{ env.FILE }}
-          
+
       - name: "Fix GIFs"
         run: |
           echo "starting gif fixing"
@@ -89,7 +89,7 @@ jobs:
           awk '{if($0~/<img src="data:image\/gif;base64,[[:alpha:],[:digit:],\/,+,=]*" \/>/) {sub(/<img src="data:image\/gif;base64,[[:alpha:],[:digit:],\/,+,=]*" \/>/,"![gif](${{ matrix.file-name }}_files\/gif_"++i".gif)")}}1' examples/jupyter-src/${{ matrix.file-name }}.md > examples/jupyter-src/tmp_${{ matrix.file-name }}.md
           mv -Force examples/jupyter-src/tmp_${{ matrix.file-name }}.md examples/jupyter-src/${{ matrix.file-name }}.md
           echo "gifs should be fixed"
-          
+
       - name: "auto-commit for gathering (retry on merge)"
         if: success()
         uses: nick-fields/retry@v3
@@ -103,6 +103,7 @@ jobs:
         with:
           timeout_minutes: 999
           max_attempts: 10
+          shell: bash
           command: |
             git fetch --all
             git stash clear
@@ -117,7 +118,7 @@ jobs:
             git config --global core.autocrlf false
             git add ${{ env.EXAMPLES_PATH }}
             git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
-            git push origin ci-example-gathering 
+            git push origin ci-example-gathering || (git reset --soft HEAD~1 && (exit 1))
 
   pluto:
     needs: [clean-ci-example-gathering-branch]
@@ -125,20 +126,20 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-        
+
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@latest
         with:
             version: '1.10'
-            
+
       - run: julia -e 'using Pkg; Pkg.add("PlutoSliderServer"); Pkg.add("FMIFlux")'
       - run: julia -e 'using PlutoSliderServer; PlutoSliderServer.export_directory("examples/pluto-src")'
-      
+
       - name: "auto-commit for gathering (retry on merge)"
         if: success()
         uses: nick-fields/retry@v3
         env: 
-          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}[${{ github.ref }}]
+          CI_COMMIT_MESSAGE: pluto-examples[${{ github.ref }}]
           CI_COMMIT_AUTHOR: github-actions[bot]
           EXAMPLES_PATH: examples
         # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
@@ -147,6 +148,7 @@ jobs:
         with:
           timeout_minutes: 999
           max_attempts: 10
+          shell: bash
           command: |
             git fetch --all
             git stash clear
@@ -162,12 +164,15 @@ jobs:
             git pull
             git add ${{ env.EXAMPLES_PATH }}
             git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
-            git push origin ci-example-gathering 
-          
+            git push origin ci-example-gathering || (git reset --soft HEAD~1 && (exit 1))
+
   filecheck: 
     needs: [jupyter, pluto]
     runs-on: ubuntu-latest
     steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+
       - name: Download examples
         run: |
           git fetch --all
@@ -181,7 +186,7 @@ jobs:
         with: 
           files: "examples/jupyter-src/*/*.svg"
           fail: true
-          
+
   auto-commit:
     needs: [jupyter, pluto, filecheck]
     if: github.event_name != 'pull_request'
@@ -189,7 +194,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        
+
       - name: Download examples
         run: |
           git fetch --all
@@ -197,7 +202,7 @@ jobs:
           git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
           git switch ci-example-gathering
           git reset --hard origin/ci-example-gathering
-          
+
       - name: auto-commit
         env: 
           CI_COMMIT_MESSAGE: Jupyter modified .ipynb & exported md files; Pluto static html exported files
@@ -222,7 +227,7 @@ jobs:
           git add ${{ env.EXAMPLES_PATH }}
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
           git push origin examples 
-          
+
   call-docu:
     needs: auto-commit
     if: github.event_name != 'pull_request'

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -14,13 +14,13 @@ on:
       - 'Project.toml'
   
 jobs:
-  jypiter:
+  jupyter-compute:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest] # , ubuntu-latest]
-        file-name: [growing_horizon_ME, modelica_conference_2021, simple_hybrid_CS, simple_hybrid_ME, mdpi_2022, juliacon_2023]
+        file-name: [growing_horizon_ME, modelica_conference_2021, simple_hybrid_CS, simple_hybrid_ME, mdpi_2022, juliacon_2023] # Caution: if altered, alter jupyter-gather-job matrix too !!!
         julia-version: ['1.10'] 
         julia-arch: [x64]
         experimental: [false]
@@ -62,9 +62,27 @@ jobs:
         if: success() && matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: jupyter-examples
+          name: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
           path: examples/jupyter-src/${{ matrix.file-name }}*
-          
+
+  jupyter-gather:
+    needs: jupyter-compute
+    runs-on: ubuntu-latest
+    env: 
+      JUPYTER_EXAMPLES: [windows-latest-growing_horizon_ME-1.10-x64-false, windows-latest-modelica_conference_2021-1.10-x64-false, windows-latest-simple_hybrid_CS-1.10-x64-false, windows-latest-simple_hybrid_ME-1.10-x64-false, windows-latest-mdpi_2022-1.10-x64-false, windows-latest-juliacon_2023-1.10-x64-false] # Caution: if altered, alter jupyter-compute-job matrix too !!!
+    steps:
+      - name: "gather jupyter artifacts"
+        uses: actions/download-artifact@v3
+        with:
+          name: jupyter-example-jupyter-example-$JUPYTER_EXAMPLES
+          path: examples/jupyter-src/
+      
+      - name: "upload combined jupyter artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: jupyter-examples
+          path: examples/jupyter-src/*
+
   pluto:
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +105,7 @@ jobs:
           path: examples/pluto-src/*
           
   filecheck: 
-    needs: [jypiter, pluto]
+    needs: [jupyter-gather, pluto]
     runs-on: ubuntu-latest
     steps:
       - name: Download jupyter examples
@@ -109,7 +127,7 @@ jobs:
           fail: true
           
   auto-commit:
-    needs: [jypiter, pluto, filecheck]
+    needs: [jupyter-gather, pluto, filecheck]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -27,10 +27,10 @@ jobs:
         
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
@@ -60,7 +60,7 @@ jobs:
           
       - name: Archive examples artifacts (success)
         if: success() && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyter-examples
           path: examples/jupyter-src/${{ matrix.file-name }}*
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
             version: '1.10'
             
@@ -81,7 +81,7 @@ jobs:
       
       - name: Archive examples artifacts (success)
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pluto-examples
           path: examples/pluto-src/*
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Download jupyter examples
         uses: actions/download-artifact@v3

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -24,20 +24,20 @@ jobs:
         julia-version: ['1.10'] 
         julia-arch: [x64]
         experimental: [false]
-
+        
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v3
-
+        
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
-
+            
       - name: "Install dependencies"
         run: julia --project=examples/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-
+        
       - name: "Install packages"
         run: pip install jupyter nbconvert
                         
@@ -48,7 +48,7 @@ jobs:
           jupyter nbconvert --ExecutePreprocessor.kernel_name="julia-1.10" --to notebook --inplace --execute ${{ env.FILE }}
           jupyter nbconvert --to script ${{ env.FILE }}
           jupyter nbconvert --to markdown ${{ env.FILE }}
-
+          
       - name: "Fix GIFs"
         run: |
           echo "starting gif fixing"
@@ -57,7 +57,7 @@ jobs:
           awk '{if($0~/<img src="data:image\/gif;base64,[[:alpha:],[:digit:],\/,+,=]*" \/>/) {sub(/<img src="data:image\/gif;base64,[[:alpha:],[:digit:],\/,+,=]*" \/>/,"![gif](${{ matrix.file-name }}_files\/gif_"++i".gif)")}}1' examples/jupyter-src/${{ matrix.file-name }}.md > examples/jupyter-src/tmp_${{ matrix.file-name }}.md
           mv -Force examples/jupyter-src/tmp_${{ matrix.file-name }}.md examples/jupyter-src/${{ matrix.file-name }}.md
           echo "gifs should be fixed"
-
+          
       - name: Archive examples artifacts (success)
         if: success() && matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3
@@ -70,15 +70,15 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v3
-
+        
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
             version: '1.10'
-
+            
       - run: julia -e 'using Pkg; Pkg.add("PlutoSliderServer"); Pkg.add("FMIFlux")'
       - run: julia -e 'using PlutoSliderServer; PlutoSliderServer.export_directory("examples/pluto-src")'
-
+      
       - name: Archive examples artifacts (success)
         if: success()
         uses: actions/upload-artifact@v3
@@ -86,14 +86,36 @@ jobs:
           name: pluto-examples
           path: examples/pluto-src/*
           
-  auto-commit:
+  filecheck: 
     needs: [jypiter, pluto]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download jupyter examples
+        uses: actions/download-artifact@v3
+        with:
+          name: jupyter-examples
+          path: examples/jupyter-src/
+          
+      - name: Download pluto examples
+        uses: actions/download-artifact@v3
+        with:
+          name: pluto-examples
+          path: examples/pluto-src/
+          
+      - name: Check if the example files generated are valid (if jupyter-examples failed, svgs are missing; jupyter command does not fail even if examples fail)
+        uses: andstor/file-existence-action@v3
+        with: 
+          files: "examples/jupyter-src/*/*.svg"
+          fail: true
+          
+  auto-commit:
+    needs: [jypiter, pluto, filecheck]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-
+        
       - name: Download jupyter examples
         uses: actions/download-artifact@v3
         with:
@@ -130,7 +152,7 @@ jobs:
           git add ${{ env.EXAMPLES_PATH }}
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
           git push origin examples 
-
+          
   call-docu:
     needs: auto-commit
     if: github.event_name != 'pull_request'

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-        
+
       - name: "clean branch"
         env: 
-          CI_COMMIT_MESSAGE: cleaned
+          CI_COMMIT_MESSAGE: cleaned[${{ github.ref }}]
           CI_COMMIT_AUTHOR: github-actions[bot]
           EXAMPLES_PATH: examples
         # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
@@ -90,30 +90,34 @@ jobs:
           mv -Force examples/jupyter-src/tmp_${{ matrix.file-name }}.md examples/jupyter-src/${{ matrix.file-name }}.md
           echo "gifs should be fixed"
           
-      - name: "auto-commit for gathering"
+      - name: "auto-commit for gathering (retry on merge)"
         if: success()
+        uses: nick-fields/retry@v3
         env: 
-          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
+          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}[${{ github.ref }}]
           CI_COMMIT_AUTHOR: github-actions[bot]
           EXAMPLES_PATH: examples
         # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
         # Reset the branch and remove all current files in the examples folder. 
         # Checkout the last stash to restore the new notebooks and apply the stash index to restore all other new files in the folder.
-        run: |
-          git fetch --all
-          git stash clear
-          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
-          git switch ci-example-gathering
-          git reset --hard origin/ci-example-gathering
-          git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
-          git stash apply --index
-          git stash drop
-          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
-          git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
-          git config --global core.autocrlf false
-          git add ${{ env.EXAMPLES_PATH }}
-          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
-          git push origin ci-example-gathering 
+        with:
+          timeout_minutes: 999
+          max_attempts: 10
+          command: |
+            git fetch --all
+            git stash clear
+            git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+            git switch ci-example-gathering
+            git reset --hard origin/ci-example-gathering
+            git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
+            git stash apply --index
+            git stash drop
+            git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+            git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
+            git config --global core.autocrlf false
+            git add ${{ env.EXAMPLES_PATH }}
+            git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+            git push origin ci-example-gathering 
 
   pluto:
     needs: [clean-ci-example-gathering-branch]
@@ -130,30 +134,35 @@ jobs:
       - run: julia -e 'using Pkg; Pkg.add("PlutoSliderServer"); Pkg.add("FMIFlux")'
       - run: julia -e 'using PlutoSliderServer; PlutoSliderServer.export_directory("examples/pluto-src")'
       
-      - name: "auto-commit for gathering"
+      - name: "auto-commit for gathering (retry on merge)"
         if: success()
+        uses: nick-fields/retry@v3
         env: 
-          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}
+          CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}[${{ github.ref }}]
           CI_COMMIT_AUTHOR: github-actions[bot]
           EXAMPLES_PATH: examples
         # Fetch all and clear the stash list. Include all files from the examples folder to the stash and switch the branch.
         # Reset the branch and remove all current files in the examples folder. 
         # Checkout the last stash to restore the new notebooks and apply the stash index to restore all other new files in the folder.
-        run: |
-          git fetch --all
-          git stash clear
-          git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
-          git switch ci-example-gathering
-          git reset --hard origin/ci-example-gathering
-          git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
-          git stash apply --index
-          git stash drop
-          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
-          git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
-          git config --global core.autocrlf false
-          git add ${{ env.EXAMPLES_PATH }}
-          git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
-          git push origin ci-example-gathering 
+        with:
+          timeout_minutes: 999
+          max_attempts: 10
+          command: |
+            git fetch --all
+            git stash clear
+            git stash --include-untracked -- ${{ env.EXAMPLES_PATH }}
+            git switch ci-example-gathering
+            git reset --hard origin/ci-example-gathering
+            git checkout stash -f -- ${{ env.EXAMPLES_PATH }}
+            git stash apply --index
+            git stash drop
+            git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+            git config --global user.email "${{ env.CI_COMMIT_AUTHOR }}@users.noreply.github.com"
+            git config --global core.autocrlf false
+            git pull
+            git add ${{ env.EXAMPLES_PATH }}
+            git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
+            git push origin ci-example-gathering 
           
   filecheck: 
     needs: [jupyter, pluto]

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           timeout_minutes: 999
           max_attempts: 10
+          warning_on_retry: false
           shell: bash
           command: |
             git fetch --all
@@ -148,6 +149,7 @@ jobs:
         with:
           timeout_minutes: 999
           max_attempts: 10
+          warning_on_retry: false
           shell: bash
           command: |
             git fetch --all

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [windows-latest] # , ubuntu-latest]
         file-name: [growing_horizon_ME, modelica_conference_2021, simple_hybrid_CS, simple_hybrid_ME, mdpi_2022, juliacon_2023]
-        julia-version: ['1.8'] 
+        julia-version: ['1.10'] 
         julia-arch: [x64]
         experimental: [false]
 
@@ -45,7 +45,7 @@ jobs:
         env:
           FILE: examples/jupyter-src/${{ matrix.file-name }}.ipynb
         run: |
-          jupyter nbconvert --ExecutePreprocessor.kernel_name="julia-1.8" --to notebook --inplace --execute ${{ env.FILE }}
+          jupyter nbconvert --ExecutePreprocessor.kernel_name="julia-1.10" --to notebook --inplace --execute ${{ env.FILE }}
           jupyter nbconvert --to script ${{ env.FILE }}
           jupyter nbconvert --to markdown ${{ env.FILE }}
 

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -27,10 +27,10 @@ jobs:
         
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
@@ -60,7 +60,7 @@ jobs:
           
       - name: Archive examples artifacts (success)
         if: success() && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v3
         with:
           name: jupyter-examples
           path: examples/jupyter-src/${{ matrix.file-name }}*
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
             version: '1.10'
             
@@ -81,7 +81,7 @@ jobs:
       
       - name: Archive examples artifacts (success)
         if: success()
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v3
         with:
           name: pluto-examples
           path: examples/pluto-src/*
@@ -91,19 +91,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download jupyter examples
-        uses: actions/download-artifact@latest
+        uses: actions/download-artifact@v3
         with:
           name: jupyter-examples
           path: examples/jupyter-src/
           
       - name: Download pluto examples
-        uses: actions/download-artifact@latest
+        uses: actions/download-artifact@v3
         with:
           name: pluto-examples
           path: examples/pluto-src/
           
       - name: Check if the example files generated are valid (if jupyter-examples failed, svgs are missing; jupyter command does not fail even if examples fail)
-        uses: andstor/file-existence-action@latest
+        uses: andstor/file-existence-action@v3
         with: 
           files: "examples/jupyter-src/*/*.svg"
           fail: true
@@ -114,16 +114,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         
       - name: Download jupyter examples
-        uses: actions/download-artifact@latest
+        uses: actions/download-artifact@v3
         with:
           name: jupyter-examples
           path: examples/jupyter-src/
       
       - name: Download pluto examples
-        uses: actions/download-artifact@latest
+        uses: actions/download-artifact@v3
         with:
           name: pluto-examples
           path: examples/pluto-src/
@@ -160,6 +160,6 @@ jobs:
     steps:
       # Trigger an repoisitory dispath event
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@latest
+        uses: peter-evans/repository-dispatch@v2
         with:
           event-type: trigger-docu

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@latest
+      - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TestLTS.yml
+++ b/.github/workflows/TestLTS.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/TestLTS.yml
+++ b/.github/workflows/TestLTS.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v3
+        uses: actions/cache@latest
         env:
           cache-name: cache-artifacts
         with:
@@ -50,18 +50,18 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
 
       # Run the tests
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@latest
 
       # Preprocess Coverage
       - name: "Preprocess Coverage"
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@latest
 
       # Run codecov
       - name: "Run CodeCov"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@latest
         with:
           file: lcov.info

--- a/.github/workflows/TestLTS.yml
+++ b/.github/workflows/TestLTS.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@latest
+        uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -50,18 +50,18 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
 
       # Run the tests
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
 
       # Preprocess Coverage
       - name: "Preprocess Coverage"
-        uses: julia-actions/julia-processcoverage@latest
+        uses: julia-actions/julia-processcoverage@v1
 
       # Run codecov
       - name: "Run CodeCov"
-        uses: codecov/codecov-action@latest
+        uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/.github/workflows/TestLatest.yml
+++ b/.github/workflows/TestLatest.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/TestLatest.yml
+++ b/.github/workflows/TestLatest.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@v3
+        uses: actions/cache@latest
         env:
           cache-name: cache-artifacts
         with:
@@ -50,18 +50,18 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
 
       # Run the tests
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@latest
 
       # Preprocess Coverage
       - name: "Preprocess Coverage"
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@latest
 
       # Run codecov
       - name: "Run CodeCov"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@latest
         with:
           file: lcov.info

--- a/.github/workflows/TestLatest.yml
+++ b/.github/workflows/TestLatest.yml
@@ -26,18 +26,18 @@ jobs:
     steps:
       # Checks-out your repository
       - name: Check out repository
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
 
      # Set up cache
       - name: "Set up cache"
-        uses: actions/cache@latest
+        uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -50,18 +50,18 @@ jobs:
 
       # Build package
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
 
       # Run the tests
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
 
       # Preprocess Coverage
       - name: "Preprocess Coverage"
-        uses: julia-actions/julia-processcoverage@latest
+        uses: julia-actions/julia-processcoverage@v1
 
       # Run codecov
       - name: "Run CodeCov"
-        uses: codecov/codecov-action@latest
+        uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ ThreadPools = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"
 [compat]
 Colors = "0.12.8"
 DifferentiableEigen = "0.2.0"
-DifferentialEquations = "7.7.0 - 7.12"
+DifferentialEquations = "7.7.0 - 7.13"
 FMIImport = "0.16.4"
 FMISensitivity = "0.1.4"
 Flux = "0.13.0 - 0.14"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ ThreadPools = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"
 [compat]
 Colors = "0.12.8"
 DifferentiableEigen = "0.2.0"
-DifferentialEquations = "7.7.0 - 7.13"
+DifferentialEquations = "7.7.0 - 7.12"
 FMIImport = "0.16.4"
 FMISensitivity = "0.1.4"
 Flux = "0.13.0 - 0.14"


### PR DESCRIPTION
- versionbump julia: 1.8->1.10
- added check for svg files to determine if jupyter building was successful (and fail action otherwise)
- updated to current versions of dependency actions
-> (due to breaking changes in artifact upload) switched from atrifacts to seperate branch for example-consolidation (ci-example-gathering)
--> added concurrency requirement: only one action is allowed to run (and push to the new branch) at the same time
