### PR TITLE
fixes for Example.yml

### DIFF
--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -62,7 +62,7 @@ jobs:
         run: julia --project=examples/ examples/jupyter-src/${{ matrix.file-name }}.jl
 
       - name: "auto-commit (retry on merge)"
-        if: success() && github.event_name != 'pull_request' && github.branch == 'main'
+        if: success() && github.event_name != 'pull_request' && github.ref_name == 'main'
         uses: nick-fields/retry@v3
         env: 
           CI_COMMIT_MESSAGE: jupyter-example-${{ matrix.os }}-${{ matrix.file-name }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}-${{ matrix.experimental }}[${{ github.ref }}]
@@ -107,7 +107,7 @@ jobs:
       - run: julia -e 'using PlutoSliderServer; PlutoSliderServer.export_directory("examples/pluto-src")'
 
       - name: "auto-commit (retry on merge)"
-        if: success() && github.event_name != 'pull_request' && github.branch == 'main'
+        if: success() && github.event_name != 'pull_request' && github.ref_name == 'main'
         uses: nick-fields/retry@v3
         env: 
           CI_COMMIT_MESSAGE: pluto-examples[${{ github.ref }}]
@@ -140,7 +140,7 @@ jobs:
 
   call-docu:
     needs: [jupyter, pluto]
-    if: github.event_name != 'pull_request' && github.branch == 'main'
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       # Trigger an repoisitory dispath event

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -643,5 +643,3 @@ function batchDataEvaluation(
 
     return batch
 end
-
-

--- a/src/optimiser.jl
+++ b/src/optimiser.jl
@@ -94,5 +94,3 @@ function apply!(optim::FluxOptimiserWrapper, params)
 end
 
 ### generic FMIFlux.AbstractOptimiser ###
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ global EXPORTINGTOOL = nothing
 global EXPORTINGVERSION = nothing
 global X0 = [2.0, 0.0]
 global OPTIMISER = Descent
-global FAILED_GRADIENTS_QUOTA = 1/3
+global FAILED_GRADIENTS_QUOTA = 1 / 3
 
 # callback for bad optimization steps counter
 global FAILED_GRADIENTS = 0


### PR DESCRIPTION
fixes for example action, that enables automatic pushes to examples branch (which in turn should make the documentation build again as soon as merged)