### PR TITLE
action-deps-version-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ''
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v2
         with:
           version: '1' # 1.6
           arch: x64

--- a/.github/workflows/Eval.yml
+++ b/.github/workflows/Eval.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}

--- a/.github/workflows/Example.yml
+++ b/.github/workflows/Example.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
             version: ${{ matrix.julia-version }}
             arch: ${{ matrix.julia-arch }}
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
             version: '1.10'
             
@@ -145,6 +145,6 @@ jobs:
     steps:
       # Trigger an repoisitory dispath event
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           event-type: trigger-docu

--- a/.github/workflows/TestLTS.yml
+++ b/.github/workflows/TestLTS.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}

--- a/.github/workflows/TestLatest.yml
+++ b/.github/workflows/TestLatest.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Set up Julia
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}


### PR DESCRIPTION
further todos: 
- fix the example action to build valid markdown files
- update docs-make.jl to match FMI.jl (pass documenter warnings to github summary & fail doc action if docstrings are missing) 
- improve pluto checkbox handling on CI-builds

You want those changes incorporated here or in a different PR (in that case, this one is ready to merge)?